### PR TITLE
Fix pwndbg url in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ sudo apt-get install -y \
 # Install [pwntools](https://docs.pwntools.com/en/stable/install.html#python3).
 sudo pip3 install --break-system-packages pwntools
 
-# Install [pwntools](https://docs.pwntools.com/en/stable/install.html#python3).
+# Install [pwndbg](https://pwndbg.re/pwndbg/latest/setup/#installing-pwndbg-gdb).
 curl -qsL 'https://install.pwndbg.re' | sh -s -- -t pwndbg-gdb
 
 # FIXME


### PR DESCRIPTION
Currently, a comment line for pwndbg describe pwntools' url incorrectly. This PR fixes this.

I replaced the line using a [`Dockerfile`](https://github.com/r1ru/binary-exploitation-101/blob/a325dcbaf396f739dfa5e4f8606c679a8f766b25/.devcontainer/Dockerfile#L28)'s comment line.